### PR TITLE
Fix running on macOS: `darwin` platform

### DIFF
--- a/enamlnativecli/main.py
+++ b/enamlnativecli/main.py
@@ -36,7 +36,7 @@ try:
 except:
     from configparser import ConfigParser
 
-IS_WIN = 'win' in sys.platform
+IS_WIN = 'win' in sys.platform and not 'darwin' == sys.platform
 
 # sh does not work on windows
 if IS_WIN:


### PR DESCRIPTION
Hi,
this pull request fix an issue with using `enaml-native` on macOS.

Without this changes I've got an error:
```
Traceback (most recent call last):
  File "/Users/eoskin/.local/share/virtualenvs/hello-enaml-native-lr6QcRz5/bin/enaml-native", line 7, in <module>
    from enamlnativecli.main import main
  File "/Users/eoskin/.local/share/virtualenvs/hello-enaml-native-lr6QcRz5/lib/python3.6/site-packages/enamlnativecli/main.py", line 58, in <module>
    raise EnvironmentError("Couldn't find a adb in your System, "
OSError: Couldn't find a adb in your System, Make sure android studio is installed
```