### PR TITLE
Fix permissions for executing './gradlew' in mac / linux

### DIFF
--- a/enamlnativecli/main.py
+++ b/enamlnativecli/main.py
@@ -1301,7 +1301,13 @@ class RunAndroid(Command):
             release_apk = os.path.abspath(join(
                 '.', 'app', 'build', 'outputs', 'apk',
                 'app-release-unsigned.apk'))
-            gradlew = sh.Command('gradlew.bat' if IS_WIN else './gradlew')
+            #: Fix permissions for running gradlew in mac / linux
+            if IS_WIN:
+                gradlew = sh.Command('gradlew.bat')
+            else:
+                gradlew = sh.Command('chmod 755 gradlew')
+                gradlew = sh.Command('./gradlew')
+            #gradlew = sh.Command('gradlew.bat' if IS_WIN else './gradlew')
             #: If no devices are connected, start the simulator
             if len(sh.adb('devices').stdout.strip())==1:
                 device = sh.emulator('-list-avds').stdout.split("\n")[0]


### PR DESCRIPTION
clears out error while running build for android because of gradlew on Mac / Linux.
permission 755 for gradlew fixes it.

ERROR RECIEVED : 

Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/opt/miniconda3/envs/helloworld/lib/python3.7/site-packages/sh.py", line 1202, in __init__
          raise CommandNotFound(path)
 sh.CommandNotFound: ./gradlew